### PR TITLE
Fix #386: Change MySQL to default to using file per table.

### DIFF
--- a/cli/stubs/my.cnf
+++ b/cli/stubs/my.cnf
@@ -5,7 +5,7 @@ host=localhost
 
 [mysqld]
 sql_mode="NO_ENGINE_SUBSTITUTION"
-innodb_file_per_table=OFF
+innodb_file_per_table=ON
 show_compatibility_56=ON
 open_files_limit=999999
 log-error=VALET_HOME_PATH/Log/mysql.log


### PR DESCRIPTION
As per issue #386 we should probably change to using file per table.

Given that this environment is for developers who may be importing and dropping lots of DBs, not being able to reclaim the disk space from MySQL is super annoying.
